### PR TITLE
Fix duplicate function generation

### DIFF
--- a/XenonRecomp/recompiler.cpp
+++ b/XenonRecomp/recompiler.cpp
@@ -255,6 +255,9 @@ void Recompiler::Analyse()
     }
 
     std::sort(functions.begin(), functions.end(), [](auto& lhs, auto& rhs) { return lhs.base < rhs.base; });
+    functions.erase(std::unique(functions.begin(), functions.end(),
+        [](auto& lhs, auto& rhs) { return lhs.base == rhs.base; }),
+        functions.end());
 }
 
 bool Recompiler::Recompile(


### PR DESCRIPTION
## Summary
- deduplicate function list in recompiler to avoid generating repeated weak
  aliases for functions such as `__restfpr_14`

## Testing
- `cmake -S . -B build` *(fails: third-party submodules missing)*

------
https://chatgpt.com/codex/tasks/task_e_6858e36b173483258a4f332538e1ac79